### PR TITLE
Add scheduled daily reset for user statuses

### DIFF
--- a/functions/src/index.ts
+++ b/functions/src/index.ts
@@ -511,10 +511,10 @@ export const onUserKeyStatusChange = onDocumentUpdated("users/{userId}", async (
   });
 
 /**
- * 毎日24:00(JST)に在室状態と鍵保有状態をリセットする
+ * 毎日23:59(JST)に在室状態と鍵保有状態をリセットする
  */
 export const resetDailyStatuses = onSchedule({
-  schedule: '0 0 * * *',
+  schedule: '59 23 * * *',
   timeZone: 'Asia/Tokyo',
 }, async () => {
   try {


### PR DESCRIPTION
## Summary
- add a scheduled Cloud Function that resets room occupancy and key possession every midnight JST
- record automatic exit/key-return logs so Slack notifications reflect the reset actions

## Testing
- npm --prefix functions run build

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_692011512b848330a16b4d0498850725)